### PR TITLE
Fix bug parscale initialization

### DIFF
--- a/R/vecchia_wrappers.R
+++ b/R/vecchia_wrappers.R
@@ -81,7 +81,7 @@ vecchia_estimate=function(data,locs,X,m=20,covmodel='matern',theta.ini,output.le
     ## find MLE of theta (given beta.hat)
     #print(negloglik.vecchia(log(theta.ini)))
     non1pars = which(theta.ini != 1)
-    parscale = rep(1, length(n.par))
+    parscale = rep(1, n.par)
     parscale[non1pars] = log(theta.ini[non1pars])
 
     opt.result=stats::optim(par=log(theta.ini),


### PR DESCRIPTION
BUG:
`n.par` is the number of parameters.
`length(n.par)` always returns 1, but we want the number of parameters `n.par` instead. So `parscale` is always initialized as a scalar instead of a vector.